### PR TITLE
Add gitignore style ignore strings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Opts include:
   fs: require('fs'),
   pathFilter: filepath => true,
   statFilter st => true,
+  ignore: [],
   maxDepth: Infinity,
   shaper: ({ root, filepath, stat, relname, basename }) => filepath
 }
@@ -80,6 +81,14 @@ The `statFilter` function allows you to filter files based on the internal stat 
 ```js
 { // exclude all directories:
   statFilter: st => !st.isDirectory()
+}
+```
+
+The `ignore` option can be a string or or array of strings that should follow gitignore style ignore strings. Files and directories that match are ignored.
+
+```js
+{ // Ignore node_modules at any depth and any file starting with a .
+  ['node_modules', '.*']
 }
 ```
 

--- a/fixtures/ignore-folder/sub-folder-file.json
+++ b/fixtures/ignore-folder/sub-folder-file.json
@@ -1,0 +1,3 @@
+{
+  "sub-folder": "content"
+}

--- a/fixtures/ignore-folder/sub-sub-folder/sub-sub-folder-file.json
+++ b/fixtures/ignore-folder/sub-sub-folder/sub-sub-folder-file.json
@@ -1,0 +1,3 @@
+{
+  "sub-sub-folder": "content"
+}

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ async function * asyncFolderWalker (dirs, opts) {
       files.sort()
 
       for (const file of files) {
-        var next = path.join(current, file)
+        const next = path.join(current, file)
         if (opts.pathFilter(next)) pending.unshift(next)
       }
       if (current === root || !opts.statFilter(st)) continue

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "bugs": {
     "url": "https://github.com/bcomnes/async-folder-walker/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ignore": "^5.1.8"
+  },
   "devDependencies": {
     "dependency-check": "^4.1.0",
     "npm-run-all": "^4.1.5",

--- a/test.js
+++ b/test.js
@@ -22,16 +22,6 @@ tap.test('Array from async iterator', async t => {
   t.equal(files.length, 4, 'expected number of files are found')
 })
 
-tap.skip('Shape example', async t => {
-  await allFiles([fixtures], {
-    shaper: fwData => {
-      console.log(fwData)
-      return fwData
-    }
-  })
-  t.pass('shape printed')
-})
-
 tap.test('No args', async t => {
   for await (const file of asyncFolderWalker()) {
     t.fail(file, 'no files should be found!')
@@ -84,7 +74,7 @@ tap.test('statFilter works', async t => {
 })
 
 tap.test('dont include root directory in response', async (t) => {
-  const root = process.cwd()
+  const root = fixtures
   for await (const file of asyncFolderWalker(root)) {
     if (file === root) t.fail('root directory should not be in results')
   }
@@ -99,4 +89,12 @@ tap.test('dont walk past the maxDepth', async t => {
     if (!correctLength) t.fail('walker walked past the depth it was supposed to')
   }
   t.pass('Walker was depth limited')
+})
+
+tap.test('ignore-folder should be ignored', async t => {
+  for await (const file of asyncFolderWalker([fixtures], {
+    ignore: ['ignore-folder', '.*']
+  })) {
+    t.notOk(file.includes('ignore-folder', 'does not include ignored files and folders'))
+  }
 })

--- a/test.js
+++ b/test.js
@@ -69,7 +69,7 @@ tap.test('pathFilter works', async t => {
     pathFilter: p => !p.includes(filterStrig)
   })
 
-  t.false(files.some(f => f.includes(filterStrig)), 'No paths include the excluded string')
+  t.notOk(files.some(f => f.includes(filterStrig)), 'No paths include the excluded string')
 })
 
 tap.test('statFilter works', async t => {
@@ -79,7 +79,7 @@ tap.test('statFilter works', async t => {
   })
 
   for (const st of stats) {
-    t.false(st.isDirectory(), 'none of the files are directories')
+    t.notOk(st.isDirectory(), 'none of the files are directories')
   }
 })
 


### PR DESCRIPTION
To make consistent with cpx2, async-folder-walker should also support gitignore style ignore strings. 